### PR TITLE
Automatic deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  # Run this workflow whenever a new commit is pushed to main.
+  push: {branches: [main]}
+
+  # Run this workflow when triggered manually in GitHub’s UI.
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - run: |
+            python -m pip install --upgrade pip
+            pip install poetry
+            poetry install --quiet
+      - run: npm ci
+      - id: date
+        run: echo "date=$(TZ=America/Los_Angeles date +'%Y-%U')" >> $GITHUB_OUTPUT
+      - id: cache-data
+        uses: actions/cache@v4
+        with:
+          path: src/.observablehq/cache
+          key: data-${{ hashFiles('src/data/*') }}-${{ steps.date.outputs.date }}
+
+      - run: poetry run npm run build
+      - run: poetry run npm run deploy -- --message "$(git log -1 --pretty=%s)" --deploy-config=./src/.observablehq/deploy.json
+        env:
+          OBSERVABLE_TOKEN: ${{ secrets.OBSERVABLE_TOKEN }}

--- a/src/.observablehq/deploy.json
+++ b/src/.observablehq/deploy.json
@@ -1,0 +1,5 @@
+{
+  "projectId": "0835085768adab92",
+  "projectSlug": "tariff-simulator",
+  "workspaceLogin": "one-campaign"
+}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployment and adds a configuration file for deployment settings. 


* Added a new workflow named `Deploy` that triggers on commits to the `main` branch and manual dispatch. It sets up Node.js and Python environments, installs dependencies using `npm` and `poetry`, caches data, builds the project, and deploys it using a deployment configuration file.
* Added a deployment configuration file specifying the project ID, project slug, and workspace login for deployment to Observable.
@fbecerra FYI