### PR TITLE
feat: deflate trade values to constant BASE_YEAR USD

### DIFF
--- a/src/data/config.py
+++ b/src/data/config.py
@@ -2,6 +2,10 @@
 
 from pathlib import Path
 
+# Reference year for constant-price deflation (shared by all loaders).
+# Matches the base year used in trade_data_explorer.
+BASE_YEAR: int = 2024
+
 
 class PATHS:
     """Collection of project data locations."""
@@ -12,7 +16,10 @@ class PATHS:
 
     INPUTS = DATA / "inputs"
 
+    # Raw BACI cache (current USD) — kept for backward compatibility.
     EXPORTS_HIST = INPUTS / "africa_exports_to_us_2002_2024_baci_raw.csv"
+    # Constant-USD BACI cache (deflated to BASE_YEAR prices).
+    EXPORTS_HIST_CONST = INPUTS / "africa_exports_to_us_2002_2024_baci_const2024.csv"
     HS_GROUPS = INPUTS / "hs_groups.json"
 
     TARIFFS = INPUTS / "tariffs"

--- a/src/data/helpers.py
+++ b/src/data/helpers.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pathlib import Path
 
-from src.data.config import PATHS
+from src.data.config import BASE_YEAR, PATHS
 
 
 def load_json(filepath: Path) -> dict:
@@ -53,6 +53,51 @@ def group_data(
         .reset_index()
     )
     return grouped
+
+
+def deflate_to_constant_usd(
+    df: pd.DataFrame,
+    id_column: str,
+    value_column: str = "value",
+    base_year: int = BASE_YEAR,
+) -> pd.DataFrame:
+    """Deflate a trade-value column from current to constant USD using IMF GDP deflators.
+
+    Uses each country's own IMF GDP deflator (via pydeflate), matching the
+    methodology in trade_data_explorer.  The DataFrame must contain a ``year``
+    column alongside ``id_column`` and ``value_column``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``id_column``, ``year``, and ``value_column``.
+    id_column:
+        Column holding ISO3 country codes (e.g. ``"exporter_iso3_code"`` for
+        BACI data, ``"iso3"`` for US Census Bureau data).
+    value_column:
+        Column holding the nominal trade value to deflate.  Defaults to
+        ``"value"`` (BACI convention); pass ``"exports"`` for US Census data.
+    base_year:
+        Target constant-price year.  Defaults to ``BASE_YEAR`` (2024).
+
+    Returns
+    -------
+    DataFrame with ``value_column`` replaced by constant-``base_year`` values
+    in the same unit as the input.
+    """
+    from pydeflate import imf_gdp_deflate
+
+    return imf_gdp_deflate(
+        data=df,
+        base_year=base_year,
+        source_currency="USA",
+        target_currency="USA",
+        id_column=id_column,
+        year_column="year",
+        value_column=value_column,
+        target_value_column=value_column,
+        update_deflators=False,
+    )
 
 
 def filter_african_countries(df: pd.DataFrame, iso_col: str) -> pd.DataFrame:

--- a/src/data/loaders/baci.py
+++ b/src/data/loaders/baci.py
@@ -1,4 +1,8 @@
 """Load and clean historical trade data from the BACI database.
+
+Trade values are deflated to constant BASE_YEAR USD using each exporter's IMF
+GDP deflator (via pydeflate), matching the methodology in trade_data_explorer.
+The deflated cache is stored at PATHS.EXPORTS_HIST_CONST.
 """
 
 import pandas as pd
@@ -7,27 +11,46 @@ from bblocks.data_importers import BACI
 from src.data.config import PATHS
 from src.data.helpers import (
     add_sector_group_column,
+    deflate_to_constant_usd,
     filter_african_countries,
     group_data,
 )
 
 
 class BaciLoader:
-    """Loader for historical BACI trade data."""
+    """Loader for historical BACI trade data (constant BASE_YEAR USD)."""
 
     def load(self) -> pd.DataFrame:
-        """Load or download trade data from BACI and cache it locally."""
-        if PATHS.EXPORTS_HIST.exists():
-            df = pd.read_csv(PATHS.EXPORTS_HIST)
+        """Load or download BACI data, deflate to constant USD, and cache.
+
+        On first call the full pipeline runs:
+          1. Download HS02 BACI bilateral data.
+          2. Filter to US imports.
+          3. Map each product to a sector group (dropping unmapped codes).
+          4. Sum to (year, exporter, sector) granularity.
+          5. Filter to African exporters.
+          6. Deflate values to constant BASE_YEAR USD using each country's
+             IMF GDP deflator.
+          7. Cache the result to PATHS.EXPORTS_HIST_CONST.
+
+        Subsequent calls read the cached CSV directly.
+        """
+        if PATHS.EXPORTS_HIST_CONST.exists():
+            df = pd.read_csv(PATHS.EXPORTS_HIST_CONST)
         else:
             baci = BACI()
             raw_df = baci.get_data(hs_version="HS02", include_country_labels=True)
-            # Keep US imports only and summarize by year/country/sector
-            df = raw_df.query("importer_iso3_code == 'USA'")
+            # Keep US imports only
+            df = raw_df.query("importer_iso3_code == 'USA'").copy()
+            # Map products to sector groups (drops unmapped rows)
             df = add_sector_group_column(df)
+            # Aggregate to (year, exporter, sector) before deflating for efficiency
             df = group_data(df, ["year", "exporter_iso3_code", "sector"])
+            # Filter to African countries (adds "country" display column)
             df = filter_african_countries(df, "exporter_iso3_code")
-            df.to_csv(PATHS.EXPORTS_HIST, index=False)
+            # Deflate to constant BASE_YEAR USD using each exporter's IMF deflator
+            df = deflate_to_constant_usd(df, id_column="exporter_iso3_code")
+            df.to_csv(PATHS.EXPORTS_HIST_CONST, index=False)
         return df
 
     @staticmethod

--- a/src/data/loaders/ustrade.py
+++ b/src/data/loaders/ustrade.py
@@ -2,6 +2,10 @@
 
 This module fetches recent US import data and combines it with tariff
 information to compute Effective Tariff Rates (ETR) and population figures.
+
+Trade values are deflated to constant BASE_YEAR USD using each exporter's IMF
+GDP deflator before averaging across years, ensuring multi-year comparisons
+are in real (inflation-adjusted) terms.
 """
 
 from pathlib import Path
@@ -10,8 +14,8 @@ import pandas as pd
 import country_converter as coco
 from bblocks.data_importers import WorldBank
 
-from src.data.config import PATHS
-from src.data.helpers import add_sector_group_column, load_json
+from src.data.config import BASE_YEAR, PATHS
+from src.data.helpers import add_sector_group_column, deflate_to_constant_usd, load_json
 from src.data import etr
 
 YEAR_RANGE = range(2022, 2025)
@@ -21,11 +25,19 @@ class UStradeLoader:
     """Loader for recent US trade data and tariff calculations."""
 
     def load(self) -> pd.DataFrame:
-        """Return fully processed trade data ready for export."""
+        """Return fully processed trade data ready for export.
 
+        Pipeline:
+          load_data  →  sector groups  →  normalize country names
+          →  deflate (constant BASE_YEAR USD)
+          →  average across years
+          →  tariff rates  →  ETR  →  population
+        """
         df = self.load_data()
         df = add_sector_group_column(df)
         df = self.normalize_country_names(df)
+        df = self.deflate(df)
+        df = self.average_years(df)
         df = self.add_rate_columns(df)
         df = self.add_etr_column(df)
         df = self.add_population_column(df)
@@ -33,21 +45,19 @@ class UStradeLoader:
         return df[ordered_columns]
 
     def load_data(self) -> pd.DataFrame:
-        """Load raw CSV files with US trade data and compute mean values by exporter country and product."""
+        """Load per-year CSV files and return one row per (year, country, product).
+
+        Callers that need a single average figure across years should call
+        ``deflate()`` (to convert to constant USD) followed by
+        ``average_years()`` before any further processing.
+        """
         raw_dfs = []
         for y in YEAR_RANGE:
             d = pd.read_csv(PATHS.INPUTS / f"africa_exports_to_us_{y}_ustrade_raw.csv")
             d = self.clean_columns(d)
+            d["year"] = y
             raw_dfs.append(d)
-        raw_df = pd.concat(raw_dfs)
-        df = (
-            raw_df.groupby(["country", "product_code"], observed=True, dropna=False)[
-                "exports"
-            ]
-            .mean()
-            .reset_index()
-        )
-        return df
+        return pd.concat(raw_dfs, ignore_index=True)
 
     @staticmethod
     def clean_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -72,6 +82,31 @@ class UStradeLoader:
         df["iso3"] = cc.pandas_convert(df["country"], to="ISO3")
         df["country"] = cc.pandas_convert(df["iso3"], to="name_short")
         return df
+
+    @staticmethod
+    def deflate(df: pd.DataFrame, base_year: int = BASE_YEAR) -> pd.DataFrame:
+        """Deflate ``exports`` from current to constant ``base_year`` USD.
+
+        Requires ``iso3`` and ``year`` columns (call ``normalize_country_names``
+        and ensure ``load_data`` has been called before this method).
+        """
+        return deflate_to_constant_usd(
+            df, id_column="iso3", value_column="exports", base_year=base_year
+        )
+
+    @staticmethod
+    def average_years(df: pd.DataFrame) -> pd.DataFrame:
+        """Average ``exports`` across years, collapsing the ``year`` column.
+
+        Groups by all non-year, non-exports columns and computes the mean
+        export value, producing one row per (country, product_code[, sector]).
+        """
+        group_cols = [c for c in df.columns if c not in ("year", "exports")]
+        return (
+            df.groupby(group_cols, observed=True, dropna=False)["exports"]
+            .mean()
+            .reset_index()
+        )
 
     @staticmethod
     def get_africa_population_data() -> pd.DataFrame:


### PR DESCRIPTION
Add IMF GDP deflators to BaciLoader and UStradeLoader for methodological consistency with trade_data_explorer.

Changes:
- config.py: add BASE_YEAR = 2024 constant; add EXPORTS_HIST_CONST path for the deflated BACI cache
- helpers.py: add shared deflate_to_constant_usd() using pydeflate's imf_gdp_deflate; accepts id_column and value_column for reuse across both loaders
- baci.py: deflate to constant USD after sector aggregation; cache to EXPORTS_HIST_CONST instead of EXPORTS_HIST
- ustrade.py: load_data() now returns per-year rows with a year column; new deflate() static method converts exports to constant BASE_YEAR USD; new average_years() collapses years after deflation; load() pipeline updated to deflate then average before rate assignment